### PR TITLE
Bug fix in prepareMesh2MeshOT

### DIFF
--- a/src/prepareMesh2MeshOT.jl
+++ b/src/prepareMesh2MeshOT.jl
@@ -23,7 +23,7 @@ end
 
 function prepareMesh2MeshOT(pFor::Array{RemoteChannel},Minv::OcTreeMesh,N::Integer,compact::Bool=true)
 
-	Mesh2Mesh = Array(RemoteChannel,length(pFor))
+	Mesh2Mesh = Array(Future,length(pFor))
 
 	# find out which workers are involved
 	workerList = []


### PR DESCRIPTION
prepareMesh2MeshOT crashes for me at the moment.

I think that 
`Mesh2Mesh = Array(RemoteChannel,length(pFor))`   (line 26)
needs to be:
`Mesh2Mesh = Array(Future,length(pFor))`
